### PR TITLE
Issue #5: added else clause to prevent a second response from being sent

### DIFF
--- a/container.js
+++ b/container.js
@@ -7,48 +7,49 @@ var verifier = require('alexa-verifier');
 // text string, and set a flag on the request object so other body parser
 // middlewares don't try to parse the body again
 module.exports = function alexaVerifierMiddleware(options) {
-	return function(req, res, next) {
-		if (!req.headers.signaturecertchainurl) {
-			// by default, strict header checking will not be enforced
-			if (typeof options !== 'undefined' && typeof options.strictHeaderCheck !== 'undefined' && options.strictHeaderCheck === true) {
-				// respond with a 401 error
-				res.status(401).json({ status: 'failure', reason: 'The signaturecertchainurl HTTP request header is invalid!' });
-			} else {
-				// ignore the check
-				return next();
-			}
-		}
+    return function(req, res, next) {
+        if (!req.headers.signaturecertchainurl) {
+            // by default, strict header checking will not be enforced
+            if (typeof options !== 'undefined' && typeof options.strictHeaderCheck !== 'undefined' && options.strictHeaderCheck === true) {
+                // respond with a 401 error
+                res.status(401).json({ status: 'failure', reason: 'The signaturecertchainurl HTTP request header is invalid!' });
+            } else {
+                // ignore the check
+                return next();
+            }
+        } else {
 
-		// mark the request body as already having been parsed so it's ignored by
-		// other body parser middlewares
-		req._body = true;
-		req.rawBody = '';
-		req.on('data', function(data) {
-			return req.rawBody += data;
-		});
+            // mark the request body as already having been parsed so it's ignored by
+            // other body parser middlewares
+            req._body = true;
+            req.rawBody = '';
+            req.on('data', function(data) {
+                return req.rawBody += data;
+            });
 
-		req.on('end', function() {
-			var cert_url, er, error, requestBody, signature;
+            req.on('end', function() {
+                var cert_url, er, error, requestBody, signature;
 
-			try {
-				req.body = JSON.parse(req.rawBody);
-			} catch (error) {
-				er = error;
-				req.body = {};
-			}
+                try {
+                    req.body = JSON.parse(req.rawBody);
+                } catch (error) {
+                    er = error;
+                    req.body = {};
+                }
 
-			cert_url = req.headers.signaturecertchainurl;
-			signature = req.headers.signature;
-			requestBody = req.rawBody;
+                cert_url = req.headers.signaturecertchainurl;
+                signature = req.headers.signature;
+                requestBody = req.rawBody;
 
-			verifier(cert_url, signature, requestBody, function(er) {
-				if (er) {
-					console.error('error validating the alexa cert:', er);
-					res.status(401).json({ status: 'failure', reason: er });
-				} else {
-					next();
-				}
-			});
-		});
-	};
+                verifier(cert_url, signature, requestBody, function(er) {
+                    if (er) {
+                        console.error('error validating the alexa cert:', er);
+                        res.status(401).json({ status: 'failure', reason: er });
+                    } else {
+                        next();
+                    }
+                });
+            });
+        }
+    };
 }


### PR DESCRIPTION
**The problem that I am fixing:**
If this middleware is being used and a request is sent that does not contain any signaturecertchainurl then the container.js file sends back a 401 response. However, the method continues to process and will then attempt to send a second 401 response, which causes an unhandled exception.

**The fix:**
The fix is to add an "else" so that if the first part fails a check and sends a 401 it does not proceed with the second part of the method.