### PR TITLE
Added test for successfully passing verifier with a valid signature.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "tap": "^10.0.0",
     "supertest": "^3.0.0",
     "express": "^4.14.1",
-    "body-parser": "^1.16.1"
+    "body-parser": "^1.16.1",
+    "sinon": "^1.17.7"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,8 @@
 'use strict'
-
-var test = require('tap').test
-var verifier = require('../')
-var httpMocks = require('node-mocks-http')
+var test = require('tap').test;
+var verifier = require('../');
+var httpMocks = require('node-mocks-http');
+var sinon = require('sinon');
 
 var invokeMiddleware = function(data, next) {
   var callbacks = {};
@@ -102,7 +102,6 @@ test('fail invalid JSON body', function(t) {
   t.end()
 });
 
-
 test('fail invalid signature', function(t) {
   var mockRes = invokeMiddleware({
     headers: {
@@ -114,9 +113,13 @@ test('fail invalid signature', function(t) {
         timestamp: new Date().getTime()
       }
     })
+  }, function() {
+    calledNext = true;
   });
 
+  var calledNext = false;
   setTimeout(function() {
+    t.equal(calledNext, false);
     t.equal(mockRes.statusCode, 401);
     t.deepEqual(JSON.parse(mockRes._getData()), {
       reason: 'certificate expiration check failed',
@@ -125,7 +128,6 @@ test('fail invalid signature', function(t) {
     t.end();
   }, 2000);
 });
-
 
 test('with express.js and body-parser incorrectly mounted', function(t) {
   var express = require('express');
@@ -150,4 +152,49 @@ test('with express.js and body-parser incorrectly mounted', function(t) {
     });
 });
 
+test('pass with correct signature', function(t) {
+  var timeout = global.setTimeout; // see https://github.com/sinonjs/sinon/issues/269
+  var ts = '2017-02-10T07:27:59Z';
+  var now = new Date(ts);
+  var clock = sinon.useFakeTimers(now.getTime());
+  var calledNext = false;
+  var mockRes = invokeMiddleware({
+    headers: {
+      signature: 'Qc8OuaGEHWeL/39XTEDYFbOCufYWpwi45rqmM2R4WaSEYcSXq+hUko/88wv48+6SPUiEddWSEEINJFAFV5auYZsnBzqCK+SO8mGNOGHmLYpcFuSEHI3eA3nDIEARrXTivqqbH/LCPJHc0tqNYr3yPZRIR2mYFndJOxgDNSOooZX+tp2GafHHsjjShCjmePaLxJiGG1DmrL6fyOJoLrzc0olUxLmnJviS6Q5wBir899TMEZ/zX+aiBTt/khVvwIh+hI/PZsRq/pQw4WAvQz1bcnGNamvMA/TKSJtR0elJP+TgCqbVoYisDgQXkhi8/wonkLhs68pN+TurbR7GyC1vxw==',
+      signaturecertchainurl: 'https://s3.amazonaws.com/echo.api/echo-api-cert-4.pem'
+    },
+    body: JSON.stringify({
+      "version": "1.0",
+      "session": {
+        "new": true,
+        "sessionId": "SessionId.7745e45d-3042-45eb-8e86-cab2cf285daf",
+        "application": {
+          "applicationId": "amzn1.ask.skill.75c997b8-610f-4eb4-bf2e-95810e15fba2"
+        },
+        "attributes": {},
+        "user": {
+          "userId": "amzn1.ask.account.AF6Z7574YHBQCNNTJK45QROUSCUJEHIYAHZRP35FVU673VDGDKV4PH2M52PX4XWGCSYDM66B6SKEEFJN6RYWN7EME3FKASDIG7DPNGFFFNTN4ZT6B64IIZKSNTXQXEMVBXMA7J3FN3ERT2A4EDYFUYMGM4NSQU4RTAQOZWDD2J7JH6P2ROP2A6QEGLNLZDXNZU2DL7BKGCVLMNA"
+        }
+      },
+      "request": {
+        "type": "IntentRequest",
+        "requestId": "EdwRequestId.fa7428b7-75d0-44c8-aebb-4c222ed48ebe",
+        "timestamp": ts,
+        "locale": "en-US",
+        "intent": {
+          "name": "HelloWorld"
+        },
+        "inDialog": false
+      }
+    })
+  }, function() {
+    calledNext = true;
+    t.equal(mockRes.statusCode, 200);
+  });
 
+  timeout(function() {
+    t.equal(calledNext, true);
+    clock.restore();
+    t.end();
+  }, 2000);
+});

--- a/test/index.js
+++ b/test/index.js
@@ -106,7 +106,7 @@ test('fail invalid signature', function(t) {
   var mockRes = invokeMiddleware({
     headers: {
       signature: 'aGVsbG8NCg==',
-      signaturecertchainurl: 'https://s3.amazonaws.com/echo.api/echo-api-cert.pem'
+      signaturecertchainurl: 'https://s3.amazonaws.com/echo.api/echo-api-cert-4.pem'
     },
     body: JSON.stringify({
       request: {
@@ -122,7 +122,7 @@ test('fail invalid signature', function(t) {
     t.equal(calledNext, false);
     t.equal(mockRes.statusCode, 401);
     t.deepEqual(JSON.parse(mockRes._getData()), {
-      reason: 'certificate expiration check failed',
+      reason: 'certificate verification failed',
       status: 'failure'
     });
     t.end();


### PR DESCRIPTION
We stub `new Date()`.
Closes #18.