### PR TITLE
Test for #14: middleware hangs when body-parser is incorrectly mounted.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "devDependencies": {
     "coveralls": "^2.11.15",
     "node-mocks-http": "^1.5.6",
-    "tap": "^10.0.0"
+    "tap": "^10.0.0",
+    "supertest": "^3.0.0",
+    "express": "^4.14.1",
+    "body-parser": "^1.16.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -125,3 +125,29 @@ test('fail invalid signature', function(t) {
     t.end();
   }, 2000);
 });
+
+
+test('with express.js and body-parser incorrectly mounted', function(t) {
+  var express = require('express');
+  var app = express();
+  app.use(require('body-parser').json());
+  app.use(verifier);
+  var server = app.listen(3000);
+  var request = require('supertest');
+  request(server)
+    .post('/')
+    .send({ x: 1 })
+    .set('signaturecertchainurl', 'dummy')
+    .set('signature', 'aGVsbG8NCg==')
+    .end(function (err, res) {
+      t.equal(res.statusCode, 400);
+      t.deepEqual(res.body, {
+        "reason": "The raw request body has already been parsed.",
+        "status": "failure"
+      });
+      server.close();
+      t.end();
+    });
+});
+
+


### PR DESCRIPTION
This was my attempt at reproducing #14, but I cannot get it to hang.